### PR TITLE
Add Eventbrite references

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,9 @@
 <div class="header">
   <h1 class="test">MPLS JR DEVS</h1>
-  <h3 class="test-h3">Coming soon...</h3>
+  <h3 class="test-h3">NEXT EVENT:</h3>
+  <a href="https://www.eventbrite.com/o/mpls-jr-devs-13951760439">
+    RSVP on Eventbrite
+  </a>
   <div class="img-container">
     <img class="computer-person-female" src="assets/img/technologist-female.png" />
     <img class="computer-person-male" src="assets/img/technologist-male.png" />


### PR DESCRIPTION
In case folks discover the group from mplsjrdevs.com, we want them to be able to RSVP straightaway!

- [x] Link to the Eventbrite Organizer page for Mpls Jr. Devs

If desired, I can also add to this pull request changes that would add the event description to the page, much like we do at [JavaScriptMN](javascriptmn.com) -- [GH link](https://github.com/JavaScriptMN/javascriptmn.github.io/blob/build/components/Meetup.js).