### PR TITLE
Remove duplicate hard-coded google analytics tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,16 +37,4 @@
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
   </body>
-  <!-- Google Analytics -->
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-105372704-1', 'auto');
-    ga('send', 'pageview');
-
-  </script>
-  <!-- End Google Analytics -->
 </html>


### PR DESCRIPTION
I forgot that we needed to remove this with https://github.com/mplsjrdevs/mplsjrdevs/pull/25. Oops!