### PR TITLE
fix social card image issue

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,11 +10,11 @@
     <meta property="og:title" content="Mpls Jr Devs" />
     <meta property="og:description" content="A community of aspiring and less experienced software engineers in Minneapolis/St. Paul" />
     <meta property="og:url" content="https://mplsjrdevs.com/"/>
-    <meta property="og:image:secure_url" content="https://mplsjrdev.com/mplsjrdevs-logo-color.jpg"/> <!-- https -->
+    <meta property="og:image:secure_url" content="%PUBLIC_URL%/mplsjrdevs-logo-color.jpg"/> <!-- https -->
     <meta property="op:image:alt" content="Mpls Jr Devs Logo"/>
     <!-- Twitter (Defines the format of the Twitter Card) -->
     <meta property="twitter:card" content="summary" />
-    <meta property="twitter:image" content="https://mplsjrdev.com/mplsjrdevs-logo-color.jpg" />
+    <meta property="twitter:image" content="%PUBLIC_URL%/mplsjrdevs-logo-color.jpg" />
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/


### PR DESCRIPTION
Images weren't being included in the social cards on Twitter and other social media platforms.  After reading some documentation I realized that for the purposes of testing %PUBLIC_URL% didn't work, but in production it should.  

I've adjusted the url's the open graph and twitter meta tags are looking to for the image, which should resolve the issue.