### PR TITLE
social meta tag hotfix

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,11 +10,11 @@
     <meta property="og:title" content="Mpls Jr Devs" />
     <meta property="og:description" content="A community of aspiring and less experienced software engineers in Minneapolis/St. Paul" />
     <meta property="og:url" content="https://mplsjrdevs.com/"/>
-    <meta property="og:image:secure_url" content="%PUBLIC_URL%/mplsjrdevs-logo-color.jpg"/> <!-- https -->
-    <meta property="op:image:alt" content="Mpls Jr Devs Logo"/>
+    <meta property="og:image" content="http://mplsjuniordevs.com/mplsjrdevs-logo-color.jpg"/>
+    <meta property="og:image:secure_url" content="https://mplsjrdevs.com/mplsjrdevs-logo-color.jpg"/>
     <!-- Twitter (Defines the format of the Twitter Card) -->
-    <meta property="twitter:card" content="summary" />
-    <meta property="twitter:image" content="%PUBLIC_URL%/mplsjrdevs-logo-color.jpg" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:image:alt" content="Minneapolis Junior Devs Logo"/>
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/

--- a/public/index.html
+++ b/public/index.html
@@ -10,11 +10,11 @@
     <meta property="og:title" content="Mpls Jr Devs" />
     <meta property="og:description" content="A community of aspiring and less experienced software engineers in Minneapolis/St. Paul" />
     <meta property="og:url" content="https://mplsjrdevs.com/"/>
-    <meta property="og:image:secure_url" content="https://mplsjrdev.com/mplsjrdevs-logo-color.jpg"/> <!-- https -->
+    <meta property="og:image:secure_url" content="%PUBLIC_URL%/mplsjrdevs-logo-color.jpg"/> <!-- https -->
     <meta property="op:image:alt" content="Mpls Jr Devs Logo"/>
     <!-- Twitter (Defines the format of the Twitter Card) -->
     <meta property="twitter:card" content="summary" />
-    <meta property="twitter:image" content="https://mplsjrdev.com/mplsjrdevs-logo-color.jpg" />
+    <meta property="twitter:image" content="%PUBLIC_URL%/mplsjrdevs-logo-color.jpg" />
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/


### PR DESCRIPTION
The image isn't resolving in the social cards so I used facebooks sharing debugger and learned that even when the image is on a secure url, the normal og:image tag is still required.  I also changed the image:alt message so that if it were read aloud it would be easier to understand.