### PR TITLE
Update diversitynow.scss

### DIFF
--- a/src/styles/diversitynow.scss
+++ b/src/styles/diversitynow.scss
@@ -4,7 +4,7 @@
     position: fixed;
     right: 0px;
     top: 55px;
-    z-index: 999;
+    z-index: 10;
     height: 130px;
     width: 130px;
     background-size: 100%;


### PR DESCRIPTION
With a zIndex of 999 the diversity banner covers up the navigation hover over text "Code of Conduct".  I tested it with a setting of 1 and scrolled through the page and the diversity banner behaved as expected.  Setting it at 10 as that also worked can could allow for other layers in the future.