### PR TITLE
Accessibility: footer section updates

### DIFF
--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -26,12 +26,12 @@ const Contact = () => {
               noValidate
             >
               <div id="mc_embed_signup_scroll">
+                <label for="mce-EMAIL">Email address:</label>
                 <input
                   type="email"
                   name="EMAIL"
                   className="email"
                   id="mce-EMAIL"
-                  placeholder="email address"
                   required
                 />{' '}
                 <div id="mc_hidden" aria-hidden="true">
@@ -66,7 +66,8 @@ const Contact = () => {
               rel="noopener noreferrer"
             >
               email us
-            </a>.
+            </a>
+            .
           </div>
         </div>
         <div className="divider" />
@@ -81,14 +82,16 @@ const Contact = () => {
               rel="noopener noreferrer"
             >
               @mplsjrdevs
-            </a>.
+            </a>
+            .
           </div>
         </div>
         <div className="divider" />
         <div className="contact-method">
           <FontAwesomeIcon icon={faQuestion} size="4x" />
           <div className="contact-text">
-            Got questions?<br />
+            Got questions?
+            <br />
             <br />
             <a
               href="mailto:mplsjrdevs@gmail.com"

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -7,7 +7,7 @@ import faQuestion from '@fortawesome/fontawesome-free-solid/faQuestion';
 
 const Contact = () => {
   return (
-    <section id="contact">
+    <footer id="contact">
       <h2>Contact</h2>
       <div className="flex-container">
         <div className="contact-method">
@@ -104,7 +104,7 @@ const Contact = () => {
           </div>
         </div>
       </div>
-    </section>
+    </footer>
   );
 };
 

--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -5,7 +5,8 @@ body {
   font-size: 16px;
 }
 
-section {
+section,
+footer {
   padding: 4rem;
 
   @media (max-width: $laptop) {

--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -94,6 +94,19 @@ img.responsive {
   clear: left;
   font: 14px Helvetica, Arial, sans-serif;
 
+  label {
+    display: inline-block;
+    width: 90%;
+    max-width: 400px;
+    padding-bottom: 5px;
+    text-align: left;
+    font-size: 14px;
+
+    @media (max-width: $tablet) {
+      width: 100%;
+    }
+  }
+
   input.email {
     width: 90%;
     max-width: 400px;

--- a/src/styles/_sections.scss
+++ b/src/styles/_sections.scss
@@ -343,13 +343,6 @@
     margin: 1rem;
     min-width: 200px;
     max-width: 400px;
-
-    label {
-      text-align: left;
-      font-size: 14px;
-      padding-left: 15px;
-      padding-bottom: 5px;
-    }
   }
 
   .divider {

--- a/src/styles/_sections.scss
+++ b/src/styles/_sections.scss
@@ -343,6 +343,13 @@
     margin: 1rem;
     min-width: 200px;
     max-width: 400px;
+
+    label {
+      text-align: left;
+      font-size: 14px;
+      padding-left: 15px;
+      padding-bottom: 5px;
+    }
   }
 
   .divider {


### PR DESCRIPTION
This is the first (of several) PRs containing accessibility upgrades for mplsjrdevs.com, which are documented over in issue #96. I'm starting with a smaller batch of updates just to get a feel for the preferred PR process and get the ball rolling. Looking forward to any questions or feedback!

## Changes made

1. Changed the Contact section to a semantic `<footer>` landmark tag.
1. Added a permanently-visible `<label>` for the email address text input, and associated it with the text input using the `for` attribute.
1. Removed the `placeholder` attribute on the text input since it now feels redundant to me, but if you really like it we can add it back :) 

Weirdly, it looks like a couple of tiny whitespace changes snuck in there somehow, but I have auto-reformatting disabled in my editor. Maybe there is a Git setting somewhere that controls platform-dependent line ending conversion (I'm on Win10)? If this irks anyone, and/or if you've seen this before, just let me know!

## Preview of changes

![contact-label](https://user-images.githubusercontent.com/422783/75380339-79cf6980-589c-11ea-8467-e2a1eded3f9d.PNG)