### PR TITLE
Fix rounded image overlay issue on safari

### DIFF
--- a/src/styles/_sections.scss
+++ b/src/styles/_sections.scss
@@ -278,6 +278,7 @@
       opacity: 0;
       transition: opacity 0.25s;
       z-index: 1;
+      border-radius: 50%;
       background: linear-gradient(
         0deg,
         rgba($blue, 0.6) 0%,


### PR DESCRIPTION
This blue square has been showing up on safari on mouse-over of a community member for years, and this simple change should fix it. Oops.

<img width="407" alt="Screen Shot 2020-05-25 at 2 15 27 PM" src="https://user-images.githubusercontent.com/2946681/82838656-7d21c380-9e92-11ea-8eb9-2a9ad55244ec.png">
