### PR TITLE
Removing unnecessary alt attribute

### DIFF
--- a/src/components/Community.js
+++ b/src/components/Community.js
@@ -74,11 +74,7 @@ class Community extends Component {
                   className="image-overlay"
                 >
                   <div className="overlay-text">{person['name']}</div>
-                  <img
-                    src={person['image']}
-                    alt={person['name']}
-                    className="community-image"
-                  />
+                  <img src={person['image']} className="community-image" />
                 </a>
               );
             })}

--- a/src/components/Community.js
+++ b/src/components/Community.js
@@ -74,7 +74,11 @@ class Community extends Component {
                   className="image-overlay"
                 >
                   <div className="overlay-text">{person['name']}</div>
-                  <img src={person['image']} className="community-image" />
+                  <img
+                    src={person['image']}
+                    className="community-image"
+                    alt=""
+                  />
                 </a>
               );
             })}


### PR DESCRIPTION
(More accessibility on the brain) The link is already labeled by the <div> with className="overlay-text".